### PR TITLE
FIX later versions of IE and relative position

### DIFF
--- a/css/ss.inlinehelp.css
+++ b/css/ss.inlinehelp.css
@@ -1,5 +1,5 @@
 .ss-inlinehelp-icon, .ss-inlinehelp-tooltip {
-	position: absolute;
+	position: absolute !important;
 	top: 0;
 }
 


### PR DESCRIPTION
Later versions of IE introduce a relative style applied on the element that breaks layouts.
